### PR TITLE
fixed RTF sector report

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -679,8 +679,8 @@ get_section_descriptions <- function(section, additional_pars=list()) {
       stop(paste("Invalid content function name", content_function))
     }
   } else {
-    if (!is.null(name)) out <- paste0("# ", name, "\n\n")
-    if (!is.null(description)) out <- paste0(out, description, "\n\n")
+    if (!is.null(section$name)) out <- paste0("# ", section$name, "\n\n")
+    if (!is.null(section$description)) out <- paste0(out, section$description, "\n\n")
   }
   return(out)
 }
@@ -1094,18 +1094,16 @@ get_report_contents <- function(inputs, report_version, report_scenario_selectio
   section_no <- get_section_no(is_rtf)
   out <- list()
   for (scenario in global$scenarios[scenario_no]) {
-    #else {
-      out <- c(
-        out,
-        list(get_scenario_descriptions(
-          aggregated_inputs,
-          inputs,
-          scenario
-        ))
-      )
-    #}
+    out <- c(
+      out,
+      list(get_scenario_descriptions(
+        aggregated_inputs,
+        inputs,
+        scenario
+      ))
+    )
   }
-  for(section in global$sections[section_no]){
+  for (section in global$sections[section_no]){
     out <- c(
         out,
         list(get_section_descriptions(

--- a/R/server.R
+++ b/R/server.R
@@ -137,7 +137,7 @@ server <- function(input, output, session) {
     } else {
       write_report_to_file(
         get_report_contents(
-          get_inputs(all_inputs(), input$inst_type, input$report_sector_selection, FALSE, "High"),
+          get_inputs(all_inputs(), "", input$report_sector_selection, FALSE, "High"),
           global$report_version,
           input$report_scenario_selection,
           FALSE,
@@ -226,7 +226,7 @@ server <- function(input, output, session) {
       } else {
         write_report_to_file(
           get_report_contents(
-            get_inputs(all_inputs(), input$inst_type, input$report_sector_selection, FALSE, "High"),
+            get_inputs(all_inputs(), "", input$report_sector_selection, FALSE, "High"),
             global$report_version,
             input$report_scenario_selection,
             TRUE,

--- a/inst/section/instruction.yml
+++ b/inst/section/instruction.yml
@@ -1,6 +1,6 @@
 position: -1
 include_in_HTML: no
-include_in_RTF: yes
+include_in_RTF: no
 description: |
   This online climate scenario analysis tool is designed to support firms
   in assessing their climate-related risks and opportunities.


### PR DESCRIPTION
The RTF sector report was not produced correctly (for sectors not applicable to base institution type, i.e. underwriting classes as the default type is bank)

additionally, small styling changes (remove commented else statement and space after if)