### PR TITLE
Bugfix

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -368,6 +368,7 @@ table_to_markdown_multiline <- function(table, dot_to_space = TRUE, col_widths =
     headers <- gsub(".", " ", headers, fixed = TRUE)
   }
   for (i in 1:ncol(table)) {
+    headers[i] <- string_format_lines(headers[i], col_widths[i] - 2)
     table[, i] <- as.character(table[, i])
     table[, i] <- gsub("\n", " ", table[, i])
     for (j in 1:nrow(table)) {
@@ -389,7 +390,7 @@ table_to_markdown_multiline <- function(table, dot_to_space = TRUE, col_widths =
   sepline[1] <- paste0("+", sepline[1])
   rowsout <- matrix(emptyline, nrow = split_rows[1], ncol = length(emptyline), byrow = F)
   for (i in 1:ncol(out)) {
-    cell_text <- string_format_lines(headers[i], col_widths[i] - 2)
+    cell_text <- headers[i]
     cell_text <- paste0(
       cell_text,
       paste(rep(" ", (col_widths[i] - 2) * split_rows[1] - nchar(cell_text)), collapse = "")
@@ -1323,7 +1324,7 @@ get_executive_summary_inputs <- function(aggregated_inputs, inputs) {
           cols_to_use <- cols_to_use[cols_to_use <= ncol]
           out <- paste0(
             out,
-            table_to_markdown_multiline(values_trimmed[, cols_to_use], col_widths = c(30, 20, 20, 20))
+            table_to_markdown_multiline(values_trimmed[, cols_to_use], col_widths = c(30, rep(20, length(cols_to_use)-1)))
           )
         }
       }

--- a/R/functions.R
+++ b/R/functions.R
@@ -1368,6 +1368,7 @@ get_test_report <- function() {
     out <- paste0(out, get_exposure_test_description(names(global$exposure_classes)[i]))
     out <- paste0(out, get_exposure_appendix(names(global$exposure_classes)[i]))
   }
+  out <- add_path_to_graphs(out)
   return(out)
 }
 


### PR DESCRIPTION
Spotted and fixed some bugs:
table_to_markdown_multiline: in some cases (not often) the header split failed. solved by ensuring proper direction of operations (split lines by full words first, then count characters)
dev_report_2: failed with image reformatting, added command giving full paths (as in the main report)
get_executive_summary_inputs: warnings were produced as the column count is not always 4. fixed by specifying the exact length of col_width