### PR TITLE
typo fix plus styler on tests

### DIFF
--- a/inst/exposure_class/sovereigns.yml
+++ b/inst/exposure_class/sovereigns.yml
@@ -78,7 +78,7 @@ physical:
 appendix: |
   ![20 Notch Rating Scale](Sovereign_Rating_Scale.png)
 
-  **Source:**: 20 Notch Rating Scale
+  **Source**: 20 Notch Rating Scale
       
 references: |
   - [The risks from climate change to sovereign debt in Europe - Bruegel, September 2021](http://bruegel.org/reader/The-risks-from-climate-change-to-sovereign-debt-in-Europe#how-exposed-are-european-sovereigns-to-climate-risk){target="\_blank"}

--- a/tests/testthat/test_links.R
+++ b/tests/testthat/test_links.R
@@ -11,13 +11,13 @@ check_link_recursive <- function(arg) {
     arg <- unlist(arg)
     links <- arg[grep("http", arg)]
     n <- length(links)
-    if (n > 0){
-        good_links <- rep(FALSE, n)
-        good_links <- good_links | grepl('{target="\\_blank"}', links, fixed = TRUE)
-        good_links <- good_links | grepl('.pdf', links, fixed = TRUE)
-        return(links[!good_links])
+    if (n > 0) {
+      good_links <- rep(FALSE, n)
+      good_links <- good_links | grepl('{target="\\_blank"}', links, fixed = TRUE)
+      good_links <- good_links | grepl(".pdf", links, fixed = TRUE)
+      return(links[!good_links])
     } else {
-        return(character(0))
+      return(character(0))
     }
   }
 }

--- a/tests/testthat/test_reports.R
+++ b/tests/testthat/test_reports.R
@@ -63,10 +63,10 @@ testthat::test_that("report files", {
       # Compare test data vs function outputs.
       expect_equal(
         sum(
-          report_files[[1]] != comparison_files[[1]] & 
-          !grepl("file24c47ab83a7c", comparison_files[[1]]) & 
-          !grepl("file24c47f0255a9", comparison_files[[1]]) &
-          !grepl("file24c43d842cad", comparison_files[[1]])
+          report_files[[1]] != comparison_files[[1]] &
+            !grepl("file24c47ab83a7c", comparison_files[[1]]) &
+            !grepl("file24c47f0255a9", comparison_files[[1]]) &
+            !grepl("file24c43d842cad", comparison_files[[1]])
         ),
         0
       )
@@ -75,7 +75,7 @@ testthat::test_that("report files", {
         sum(report_files[[2]] != comparison_files[[2]]),
         0
       )
-      
+
       expect_equal(
         sum(report_files[[3]] != comparison_files[[3]]),
         0


### PR DESCRIPTION
double colon removed in sovereign text
plus I missed to include styler changes in tests in previous push 