### PR TITLE
explicitly define some package resource paths at app start

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -107,4 +107,12 @@ initialise_globals <- function() {
   if (global$report_version >= 7) {
     future::plan(future::multisession)
   }
+
+  # explicitly define resource paths for some libraries
+  folder <- system.file("htmlwidgets/lib", package="tippy")
+  addResourcePath(dir(folder), paste0(folder, "/", dir(folder)))
+  addResourcePath(paste0("tippy-binding-", "0.0.1"), system.file("www", package="htmlwidgets"))
+  addResourcePath(paste0("htmlwidgets-", packageVersion("htmlwidgets")), system.file("htmlwidgets", package="tippy"))
+  addResourcePath(paste0("mdInput-", packageVersion("shinymarkdown")), system.file("assets", package="shinymarkdown"))
+
 }


### PR DESCRIPTION
as in the title. I added the paths that seem missing basing on what is displayed by resourcePaths on local machine